### PR TITLE
feat: Implement Web Search, History, and UI Enhancements

### DIFF
--- a/lib/core/models/message_model.dart
+++ b/lib/core/models/message_model.dart
@@ -97,4 +97,13 @@ class WebSearchMessage extends Message {
           type: MessageType.assistant,
           timestamp: DateTime.now(),
         );
+
+  factory WebSearchMessage.fromJson(
+      Map<String, dynamic> json, Map<String, dynamic> metadata) {
+    return WebSearchMessage(
+      id: json['id'],
+      query: metadata['query'] ?? '',
+      searchResult: WebSearchResult.fromJson(metadata['searchResult']),
+    );
+  }
 }

--- a/lib/core/models/web_search_result_model.dart
+++ b/lib/core/models/web_search_result_model.dart
@@ -6,6 +6,7 @@ class WebSearchResult {
   final List<ImageResult> images;
   final String? rawJson; // For debugging
   final bool hasError;
+  final String? errorMessage;
 
   WebSearchResult({
     required this.webPages,
@@ -13,6 +14,7 @@ class WebSearchResult {
     required this.images,
     this.rawJson,
     this.hasError = false,
+    this.errorMessage,
   });
 
   factory WebSearchResult.fromJson(Map<String, dynamic> json) {

--- a/lib/core/services/chat_history_service.dart
+++ b/lib/core/services/chat_history_service.dart
@@ -253,6 +253,8 @@ class ChatHistoryService extends ChangeNotifier {
             return FlashcardMessage.fromJson(json, metadata!);
           case 'quiz':
             return QuizMessage.fromJson(json, metadata!);
+          case 'web_search':
+            return WebSearchMessage.fromJson(json, metadata!);
           default:
             return Message(
               id: json['id'],
@@ -354,6 +356,12 @@ class ChatHistoryService extends ChangeNotifier {
           'type': 'quiz',
           'prompt': message.prompt,
           'questions': message.questions.map((q) => q.toJson()).toList(),
+        };
+      } else if (message is WebSearchMessage) {
+        data['metadata'] = {
+          'type': 'web_search',
+          'query': message.query,
+          'searchResult': message.searchResult.toJson(),
         };
       }
 

--- a/lib/core/services/web_search_service.dart
+++ b/lib/core/services/web_search_service.dart
@@ -30,6 +30,8 @@ class WebSearchService {
             images: [],
             hasError: true,
             rawJson: response.body,
+            errorMessage:
+                'The web search service returned data in an unexpected format. This may be a temporary issue.',
           );
         }
       } else {
@@ -42,6 +44,8 @@ class WebSearchService {
           images: [],
           hasError: true,
           rawJson: response.body, // The body might have useful error info
+          errorMessage:
+              'The web search service is temporarily unavailable (Error ${response.statusCode}). Please try again later.',
         );
       }
     } catch (e) {
@@ -52,6 +56,8 @@ class WebSearchService {
         newsArticles: [],
         images: [],
         hasError: true,
+        errorMessage:
+            'A network error occurred while trying to search the web. Please check your connection and try again.',
         rawJson: '{"error": "A network or client-side error occurred: $e"}',
       );
     }

--- a/lib/features/chat/widgets/web_search_results_widget.dart
+++ b/lib/features/chat/widgets/web_search_results_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../core/models/web_search_result_model.dart';
@@ -36,7 +37,16 @@ class WebSearchResultsWidget extends StatelessWidget {
           const SizedBox(height: 12),
           if (result.webPages.isNotEmpty) ...[
             _buildSectionHeader(context, 'Web Pages', CupertinoIcons.globe),
-            ...result.webPages.take(3).map((page) => _buildWebPageResult(context, page)),
+            Container(
+              constraints: const BoxConstraints(maxHeight: 280),
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: result.webPages.length,
+                itemBuilder: (context, index) {
+                  return _buildWebPageResult(context, result.webPages[index]);
+                },
+              ),
+            ),
             const SizedBox(height: 12),
           ],
           if (result.newsArticles.isNotEmpty) ...[
@@ -119,17 +129,19 @@ class WebSearchResultsWidget extends StatelessWidget {
                         ),
                   ),
                   const SizedBox(height: 4),
-                  Text(
-                    page.snippet,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onSurface
-                              .withOpacity(0.7),
-                        ),
+                  MarkdownBody(
+                    data: page.snippet,
+                    styleSheet: MarkdownStyleSheet.fromTheme(
+                      Theme.of(context),
+                    ).copyWith(
+                      p: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withOpacity(0.7),
+                          ),
                     ),
+                  ),
                 ],
               ),
               ),


### PR DESCRIPTION
This commit introduces a major new feature: AI-powered web search via tool-calling. The model can now autonomously decide to search the web to answer user queries.

Key changes include:
- **Web Search Tool**: The AI can now search the web. The payload sent back to the AI for summarization is refined to only include titles and snippets.
- **Chat History**: Web search results (`WebSearchMessage`) are now correctly serialized and saved to the chat history, ensuring they persist across sessions.
- **UI Enhancements**:
    - The web search results widget now features a scrollable list for web pages and renders snippets using Markdown.
    - Improved error handling provides specific, user-friendly messages for network, server (e.g., 503), and data parsing errors.
- **Numerous Fixes**: This commit also bundles a wide array of bug fixes and UI/UX improvements from previous iterations, including a new splash screen animation, smoother page transitions, corrected vision API calls, and a consistent dark theme for code blocks.